### PR TITLE
Add Jest setup and header test

### DIFF
--- a/__tests__/Header.test.tsx
+++ b/__tests__/Header.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import Header from '@/components/Header/Header';
+
+jest.mock('next/navigation', () => ({
+  usePathname() {
+    return '/';
+  },
+}));
+
+describe('Header', () => {
+  it('renders logo', () => {
+    render(<Header />);
+    expect(screen.getByText('MEDITHEONE')).toBeInTheDocument();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,15 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({
+  dir: './',
+});
+
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  testEnvironment: 'jest-environment-jsdom',
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.47.13",
@@ -25,6 +26,12 @@
     "eslint-config-next": "15.1.4",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/jest": "^29.5.11",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- configure Jest with `next/jest`
- add `jest.setup.ts` for RTL
- create a basic Header component test
- add test script and dev dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421aaa8c08833189574bcbc86006d6