### PR TITLE
Fix hero section animation duration

### DIFF
--- a/src/components/HeroSection/HeroSection.tsx
+++ b/src/components/HeroSection/HeroSection.tsx
@@ -56,7 +56,7 @@ export default function HeroSection() {
         <div className="relative w-full h-full overflow-hidden rounded-2xl"> {/* Added rounded-2xl here */}
           {isTransitioning ? (
             <>
-              <div className="absolute w-full h-full transition-transform duration-2000 ease-out" // Duration changed
+              <div className="absolute w-full h-full transition-transform duration-[2000ms] ease-out" // Duration changed
                    style={{ transform: `translateX(${prevIndex > currentIndex ? '100%' : '-100%'})` }}>
                 <Image
                   src={slides[prevIndex].image}
@@ -66,7 +66,7 @@ export default function HeroSection() {
                   priority
                 />
               </div>
-              <div className="absolute w-full h-full transition-transform duration-2000 ease-out" // Duration changed
+              <div className="absolute w-full h-full transition-transform duration-[2000ms] ease-out" // Duration changed
                    style={{ transform: `translateX(${prevIndex > currentIndex ? '-100%' : '100%'})` }}>
                 <Image
                   src={image}


### PR DESCRIPTION
## Summary
- tweak durations in `HeroSection` animations

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421a9e469483318961b85ad48344d1